### PR TITLE
Allow CORS requests to the localhost api server

### DIFF
--- a/app/server/apiServer.js
+++ b/app/server/apiServer.js
@@ -19,6 +19,11 @@ var myLogger = function (req, res, next) {
 };
 app.use(myLogger);
 
+app.use(function(req, res, next) {
+  res.header("Access-Control-Allow-Origin", "*");
+  res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+  next();
+});
 
 app.get('/', function (req, res) {
     res.send("Blink1Control2 API server\n\n");


### PR DESCRIPTION
 - Sets Access-Control-Allow-Origin header to ‘*’ for all
   blink2Control2 local api endpoints
 - Allows remote-hosted, browser-based
   javascript to make requests to the local api